### PR TITLE
Removes reading logs from DPUs

### DIFF
--- a/src/host/relu_f.cpp
+++ b/src/host/relu_f.cpp
@@ -114,9 +114,6 @@ int relu_f(const float *input, float *output, size_t size) {
   to_mram(set, "buffer", input, size);
   DPU_ASSERT(dpu_launch(set, DPU_SYNCHRONOUS));
 
-  dpu_set_t dpu;
-  DPU_FOREACH(set, dpu) { DPU_ASSERT(dpu_log_read(dpu, stdout)); }
-
   from_mram(set, "buffer", output, size);
   return 0;
 }

--- a/src/host/vector_add_mul.cpp
+++ b/src/host/vector_add_mul.cpp
@@ -52,9 +52,6 @@ int vec_add_mul_f(const float *input_a, const float *input_b, float *output, int
 
   DPU_ASSERT(dpu_launch(set, DPU_SYNCHRONOUS));
 
-  dpu_set_t dpu;
-  DPU_FOREACH(set, dpu) { DPU_ASSERT(dpu_log_read(dpu, stdout)); }
-
   from_mram2(set, "buffer_a", output, size);
   DPU_ASSERT(dpu_free(set));
   return 0;


### PR DESCRIPTION
dpu_log_read was printing something by itself, even when no logs in DPU. Removing